### PR TITLE
Fix Inconsistency in Function Names

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -28,7 +28,7 @@ describe('drivers', function () {
     });
   });
 
-  describe('destructivelyUpdatedriverWithKeyAndValue(driver, key, value)', function () {
+  describe('destructivelyUpdateDriverWithKeyAndValue(driver, key, value)', function () {
     it('updates `driver` with the given `key` and `value` (it is destructive) and returns the entire updated driver', function () {
       expect(destructivelyUpdateDriverWithKeyAndValue(driver, 'address', '12 Broadway')).to.eql({
         name: 'Sam',


### PR DESCRIPTION
There was an issue a user had (described below in the image) that was a result of a function name on this file not being the same as the expected function name in the test.

![image](https://user-images.githubusercontent.com/2770126/32476196-bedad0dc-c343-11e7-89ed-3f2dad975ac2.png)
